### PR TITLE
ci: add GitHub Actions CI workflow (#52)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  # ─── Python pipeline tests ────────────────────────────────────────────
+  pipeline-tests:
+    name: Pipeline tests (Python 3.12)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pipeline/requirements.txt
+
+      - name: Install dependencies
+        working-directory: pipeline
+        run: pip install -r requirements.txt
+
+      - name: Run pytest
+        working-directory: pipeline
+        run: pytest --tb=short -q
+
+  # ─── Frontend tests ───────────────────────────────────────────────────
+  frontend-tests:
+    name: Frontend tests (Node 22)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run vitest
+        working-directory: frontend
+        run: npm run test


### PR DESCRIPTION
## What

Adds `.github/workflows/ci.yml` — automated test gate on every PR to `main`.

## Why now (Sprint 2, not Sprint 7)

Tests already exist (12 Python + 4 TypeScript) but nothing runs them automatically. Without this, every PR merges blind. Splitting from #43 which was too broad.

## What runs

| Job | Runtime | Command |
|-----|---------|---------|
| `pipeline-tests` | Python 3.12, ubuntu-latest | `pytest --tb=short -q` |
| `frontend-tests` | Node 22, ubuntu-latest | `npm ci && npm run test` |

Both jobs use dependency caching (pip / npm) to keep runs fast.

## Triggers

- Every PR targeting `main`
- Every direct push to `main`

## Checklist

- [x] One issue, one branch, one PR
- [x] `Closes #52` in commit message
- [x] Branch deleted on merge

Closes #52
