### PR TITLE
fix(pipeline): resolve ModuleNotFoundError — add sys.path bootstrap

### DIFF
--- a/pipeline/run.py
+++ b/pipeline/run.py
@@ -15,6 +15,13 @@ import argparse
 import sys
 from pathlib import Path
 
+# Ensure the project root (parent of `pipeline/`) is on sys.path so that
+# `from pipeline.X import ...` resolves correctly whether run.py is invoked
+# directly (`python run.py`) or as a module (`python -m pipeline.run`).
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
 from pipeline.config import BBOX, CITY, OUTPUT_DIR, USE_OVERTURE
 from pipeline.stages.fetch_buildings import fetch_osm_buildings
 from pipeline.stages.fetch_overture import fetch_overture_buildings, merge_osm_overture

--- a/pipeline/stages/fetch_roads.py
+++ b/pipeline/stages/fetch_roads.py
@@ -7,7 +7,7 @@ Downloads the road/path network from OSM and classifies into visual hierarchy.
 import osmnx as ox
 import geopandas as gpd
 
-from pipeline.config import OSM_TIMEOUT
+from ..config import OSM_TIMEOUT
 
 
 # Visual hierarchy mapping

--- a/pipeline/tests/conftest.py
+++ b/pipeline/tests/conftest.py
@@ -3,5 +3,6 @@ import pytest
 import sys
 from pathlib import Path
 
-# Ensure pipeline package is importable
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+# Ensure the project root (parent of `pipeline/`) is on sys.path.
+# __file__ is pipeline/tests/conftest.py → .parent.parent.parent = 3d_map_navigation/
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))


### PR DESCRIPTION
Fixes #54

## Changes

- **`pipeline/run.py`**: Insert project root onto `sys.path` before any package imports. This allows `python run.py` to be invoked from inside `pipeline/` or from the project root without `ModuleNotFoundError`.
- **`pipeline/stages/fetch_roads.py`**: Switch to relative import (`from ..config import OSM_TIMEOUT`), consistent with how all other stage modules should reference sibling packages.
- **`pipeline/tests/conftest.py`**: Fix path depth — was inserting `pipeline/` onto `sys.path` (one level too shallow). Now inserts `3d_map_navigation/` so `from pipeline.X import` resolves correctly in every test file.

## Tested

```bash
cd pipeline
python -c "import run; print('Imports OK')"  # Imports OK
```
