### PR TITLE
fix(frontend): replace MapTiler basemap with OpenFreeMap — resolves 403 on localhost

### DIFF
--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -15,7 +15,11 @@ export const INITIAL_VIEW_STATE = {
 } as const;
 
 // ─── Tile URLs ───────────────────────────────────────────────────────
-export const BASEMAP_STYLE_URL = `https://api.maptiler.com/maps/streets-v2/style.json?key=${MAPTILER_API_KEY}`;
+// OpenFreeMap: free, no API key, no domain restrictions — works on localhost.
+// MapTiler streets-v2 returns 403 on localhost due to key domain restrictions.
+// Switch back to MapTiler once the key's allowed referrers include localhost.
+export const BASEMAP_STYLE_URL = 'https://tiles.openfreemap.org/styles/liberty';
+// MapTiler key still used for terrain DEM tiles (Sprint 3 feature).
 export const TERRAIN_DEM_URL = `https://api.maptiler.com/tiles/terrain-rgb-v2/tiles.json?key=${MAPTILER_API_KEY}`;
 
 // ─── Data Endpoints ──────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #56

## Problem

`BASEMAP_STYLE_URL` pointed to `api.maptiler.com/maps/streets-v2` which returns **403** on localhost — MapTiler API keys block all referrers by default unless explicitly whitelisted. This caused a cascading WebGL crash in deck.gl:

```
AJAXError: (403) https://api.maptiler.com/maps/streets-v2/style.json
Uncaught TypeError: Cannot read properties of undefined (reading 'maxTextureDimension2D')
```

## Fix

`BASEMAP_STYLE_URL` now points to **OpenFreeMap** (`tiles.openfreemap.org/styles/liberty`):
- No API key
- No domain restrictions  
- Works on localhost immediately
- OSM-based vector tiles, same visual quality

`TERRAIN_DEM_URL` (MapTiler terrain RGB) is unchanged — it's a Sprint 3 feature not loaded at runtime yet.

## Tested

App loads at http://localhost:5173 — base map renders, 628 buildings visible with 3D extrusion, 1173 road segments visible.
