### PR TITLE
feat: POI amenity layer — pipeline + ScatterplotLayer (#22 #23)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import HeightLegend from './components/HeightLegend';
 import TypeLegend from './components/TypeLegend';
 import PerfOverlay from './components/PerfOverlay';
 import Attribution from './components/Attribution';
+import PoiPanel from './components/PoiPanel';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -23,6 +24,7 @@ export default function App() {
         <HeightLegend />
         <TypeLegend />
         <PerfOverlay />
+        <PoiPanel />
         <Attribution />
       </div>
     </QueryClientProvider>

--- a/frontend/src/components/Controls.tsx
+++ b/frontend/src/components/Controls.tsx
@@ -12,6 +12,8 @@ export default function Controls() {
   const toggleWireframe = useMapStore((s) => s.toggleWireframe);
   const showLandmarks = useMapStore((s) => s.showLandmarks);
   const toggleLandmarks = useMapStore((s) => s.toggleLandmarks);
+  const showPois = useMapStore((s) => s.showPois);
+  const togglePois = useMapStore((s) => s.togglePois);
   const selectedBuilding = useMapStore((s) => s.selectedBuilding);
   const setSelectedBuilding = useMapStore((s) => s.setSelectedBuilding);
   const colourMode = useMapStore((s) => s.colourMode);
@@ -49,6 +51,11 @@ export default function Controls() {
       </label>
 
       <label style={labelStyle}>
+        <input type="checkbox" checked={showPois} onChange={togglePois} />
+        POIs
+      </label>
+
+      <label style={labelStyle}>
         <input type="checkbox" checked={showPerfOverlay} onChange={togglePerfOverlay} />
         Stats overlay
       </label>
@@ -79,6 +86,9 @@ export default function Controls() {
         <div style={{ marginTop: 12, fontSize: 11, opacity: 0.8, lineHeight: 1.6 }}>
           <div>Buildings: {metadata.stats.buildings_count.toLocaleString()}</div>
           <div>Roads: {metadata.stats.roads_count.toLocaleString()}</div>
+          {'pois_count' in metadata.stats && (
+            <div>POIs: {(metadata.stats as Record<string, number>).pois_count.toLocaleString()}</div>
+          )}
           <div>Known heights: {metadata.stats.pct_known_height.toFixed(0)}%</div>
           <div style={{ fontSize: 10, opacity: 0.6, marginTop: 4 }}>
             Generated: {new Date(metadata.generated_at).toLocaleDateString()}

--- a/frontend/src/components/PoiPanel.tsx
+++ b/frontend/src/components/PoiPanel.tsx
@@ -1,0 +1,98 @@
+import type React from 'react';
+import { useMapStore } from '../store/mapStore';
+import type { PoiProperties } from '../types';
+import { POI_CATEGORY_EMOJI } from '../utils/constants';
+
+/**
+ * Floating panel shown on the right side when a POI is clicked.
+ * Mirrors the style of the Controls panel on the left.
+ */
+export default function PoiPanel() {
+  const selectedPoi = useMapStore((s) => s.selectedPoi);
+  const setSelectedPoi = useMapStore((s) => s.setSelectedPoi);
+
+  if (!selectedPoi) return null;
+
+  const p = selectedPoi.properties as PoiProperties;
+  const emoji = POI_CATEGORY_EMOJI[p.category] ?? '📌';
+  const coords = (selectedPoi.geometry as GeoJSON.Point).coordinates;
+
+  return (
+    <div style={panelStyle}>
+      <div style={headerStyle}>
+        <span style={{ fontSize: 22, lineHeight: 1 }}>{emoji}</span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontWeight: 700, fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {p.name || '(unnamed)'}
+          </div>
+          <div style={{ fontSize: 11, opacity: 0.65, textTransform: 'capitalize' }}>
+            {p.category} · {p.amenity_tag.replace(/_/g, ' ')}
+          </div>
+        </div>
+      </div>
+
+      <div style={rowsStyle}>
+        <Row label="Category" value={p.category.charAt(0).toUpperCase() + p.category.slice(1)} />
+        <Row label="Type" value={p.amenity_tag.replace(/_/g, ' ')} />
+        {p.name && <Row label="Name" value={p.name} />}
+        <Row
+          label="Location"
+          value={`${coords[1].toFixed(5)}, ${coords[0].toFixed(5)}`}
+        />
+      </div>
+
+      <button onClick={() => setSelectedPoi(null)} style={clearBtnStyle}>
+        ✕ Close
+      </button>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ display: 'flex', gap: 6, fontSize: 11, marginBottom: 3 }}>
+      <span style={{ opacity: 0.5, minWidth: 60 }}>{label}</span>
+      <span style={{ fontWeight: 500 }}>{value}</span>
+    </div>
+  );
+}
+
+const panelStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 16,
+  right: 16,
+  background: 'rgba(255, 255, 255, 0.93)',
+  backdropFilter: 'blur(8px)',
+  borderRadius: 10,
+  padding: '14px 16px',
+  fontFamily: 'system-ui, sans-serif',
+  fontSize: 13,
+  boxShadow: '0 2px 12px rgba(0,0,0,0.15)',
+  zIndex: 5,
+  minWidth: 200,
+  maxWidth: 260,
+};
+
+const headerStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: 10,
+  alignItems: 'flex-start',
+  marginBottom: 10,
+  paddingBottom: 10,
+  borderBottom: '1px solid rgba(0,0,0,0.08)',
+};
+
+const rowsStyle: React.CSSProperties = {
+  lineHeight: 1.7,
+  marginBottom: 10,
+};
+
+const clearBtnStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '4px 0',
+  fontSize: 11,
+  border: '1px solid #ccc',
+  borderRadius: 4,
+  background: 'transparent',
+  cursor: 'pointer',
+};

--- a/frontend/src/hooks/useMapData.ts
+++ b/frontend/src/hooks/useMapData.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import type { GeoJsonFeatureCollection, BuildingProperties, RoadProperties, PipelineMetadata } from '../types';
-import { BUILDINGS_URL, ROADS_URL, METADATA_URL } from '../utils/constants';
+import type { GeoJsonFeatureCollection, BuildingProperties, RoadProperties, PoiProperties, PipelineMetadata } from '../types';
+import { BUILDINGS_URL, ROADS_URL, POIS_URL, METADATA_URL } from '../utils/constants';
 
 async function fetchJson<T>(url: string): Promise<T> {
   const res = await fetch(url);
@@ -23,6 +23,16 @@ export function useRoadsData() {
   return useQuery<GeoJsonFeatureCollection<RoadProperties>>({
     queryKey: ['roads'],
     queryFn: () => fetchJson(ROADS_URL),
+    staleTime: Infinity,
+    retry: 2,
+  });
+}
+
+/** Fetch POIs GeoJSON */
+export function usePoisData() {
+  return useQuery<GeoJsonFeatureCollection<PoiProperties>>({
+    queryKey: ['pois'],
+    queryFn: () => fetchJson(POIS_URL),
     staleTime: Infinity,
     retry: 2,
   });

--- a/frontend/src/layers/poiLayer.ts
+++ b/frontend/src/layers/poiLayer.ts
@@ -1,0 +1,42 @@
+/**
+ * POI layer — ScatterplotLayer coloured by amenity category.
+ *
+ * Each feature is a GeoJSON Point (centroid of the OSM node/polygon).
+ * Radius is fixed at 10 m so dots are always legible without overwhelming
+ * the building view. radiusMinPixels keeps them visible when zoomed out.
+ */
+import { ScatterplotLayer } from '@deck.gl/layers';
+import type { GeoJsonFeatureCollection, PoiProperties } from '../types';
+import { POI_CATEGORY_COLORS } from '../utils/constants';
+
+const DEFAULT_COLOR: [number, number, number, number] = [140, 140, 140, 230];
+
+export function createPoiLayer(
+  pois: GeoJsonFeatureCollection<PoiProperties> | null,
+): ScatterplotLayer | null {
+  if (!pois || pois.features.length === 0) return null;
+
+  return new ScatterplotLayer({
+    id: 'pois',
+    data: pois.features,
+    pickable: true,
+    stroked: true,
+    filled: true,
+    radiusUnits: 'meters',
+    radiusScale: 1,
+    radiusMinPixels: 4,
+    radiusMaxPixels: 18,
+    lineWidthMinPixels: 1,
+    getPosition: (f) => {
+      const coords = (f as GeoJSON.Feature<GeoJSON.Point>).geometry.coordinates;
+      return [coords[0], coords[1], 0];
+    },
+    getRadius: () => 10,
+    getFillColor: (f) => {
+      const cat = (f.properties as PoiProperties).category;
+      return POI_CATEGORY_COLORS[cat] ?? DEFAULT_COLOR;
+    },
+    getLineColor: [255, 255, 255, 180],
+    getLineWidth: 1,
+  });
+}

--- a/frontend/src/store/mapStore.ts
+++ b/frontend/src/store/mapStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { MapStoreState, ViewState, GeoJsonFeature, BuildingProperties, HoverInfo } from '../types';
+import type { MapStoreState, ViewState, GeoJsonFeature, BuildingProperties, PoiProperties, HoverInfo } from '../types';
 import { INITIAL_VIEW_STATE } from '../utils/constants';
 
 export const useMapStore = create<MapStoreState>((set) => ({
@@ -37,6 +37,12 @@ export const useMapStore = create<MapStoreState>((set) => ({
   selectedBuilding: null,
   setSelectedBuilding: (b: GeoJsonFeature<BuildingProperties> | null) =>
     set({ selectedBuilding: b }),
+
+  showPois: true,
+  togglePois: () => set((s) => ({ showPois: !s.showPois })),
+
+  selectedPoi: null,
+  setSelectedPoi: (p: GeoJsonFeature<PoiProperties> | null) => set({ selectedPoi: p }),
 
   hoverInfo: null,
   setHoverInfo: (info: HoverInfo | null) => set({ hoverInfo: info }),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -26,6 +26,16 @@ export interface BuildingProperties {
   fill_color?: [number, number, number, number];
 }
 
+// ─── POI Properties ──────────────────────────────────────────────────
+export interface PoiProperties {
+  /** Display name (empty string when unknown) */
+  name: string;
+  /** Broad display category: food | healthcare | education | finance | accommodation | culture | shopping | other */
+  category: string;
+  /** Raw OSM tag value, e.g. "restaurant" */
+  amenity_tag: string;
+}
+
 // ─── Road Properties ─────────────────────────────────────────────────
 export interface RoadProperties {
   /** Road name */
@@ -105,6 +115,14 @@ export interface MapStoreState {
 
   selectedBuilding: GeoJsonFeature<BuildingProperties> | null;
   setSelectedBuilding: (b: GeoJsonFeature<BuildingProperties> | null) => void;
+
+  /** POI layer toggle */
+  showPois: boolean;
+  togglePois: () => void;
+
+  /** Clicked POI for the detail panel */
+  selectedPoi: GeoJsonFeature<PoiProperties> | null;
+  setSelectedPoi: (p: GeoJsonFeature<PoiProperties> | null) => void;
 
   hoverInfo: HoverInfo | null;
   setHoverInfo: (info: HoverInfo | null) => void;

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -30,7 +30,33 @@ export const AWS_TERRAIN_TILES_URL = 'https://s3.amazonaws.com/elevation-tiles-p
 // ─── Data Endpoints ──────────────────────────────────────────────────
 export const BUILDINGS_URL = `${DATA_BASE_URL}/buildings.geojson`;
 export const ROADS_URL = `${DATA_BASE_URL}/roads.geojson`;
+export const POIS_URL = `${DATA_BASE_URL}/pois.geojson`;
 export const METADATA_URL = `${DATA_BASE_URL}/metadata.json`;
+
+// ─── POI Category Colours ──────────────────────────────────────────────────────────
+/** RGBA colour per POI category, matching the ETL classification. */
+export const POI_CATEGORY_COLORS: Record<string, [number, number, number, number]> = {
+  food:          [255, 140,   0, 230],  // amber
+  healthcare:    [220,  50,  50, 230],  // red
+  education:     [ 70, 130, 180, 230],  // steel blue
+  finance:       [ 46, 139,  87, 230],  // sea green
+  accommodation: [148, 103, 189, 230],  // purple
+  culture:       [186,  85, 211, 230],  // medium orchid
+  shopping:      [ 31, 119, 180, 230],  // blue
+  other:         [140, 140, 140, 230],  // grey
+};
+
+/** Emoji label shown in the POI detail panel per category. */
+export const POI_CATEGORY_EMOJI: Record<string, string> = {
+  food:          '🍴',
+  healthcare:    '🏥',
+  education:     '🏫',
+  finance:       '🏦',
+  accommodation: '🏨',
+  culture:       '🎭',
+  shopping:      '🛍️',
+  other:         '📍',
+};
 
 // ─── Height → Color Scale ────────────────────────────────────────────
 /** Low buildings → cool blue, mid → green/yellow, tall → red */

--- a/pipeline/run.py
+++ b/pipeline/run.py
@@ -24,6 +24,7 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from pipeline.config import BBOX, CITY, OUTPUT_DIR, USE_OVERTURE
 from pipeline.stages.fetch_buildings import fetch_osm_buildings
+from pipeline.stages.fetch_pois import fetch_pois
 from pipeline.stages.fetch_overture import fetch_overture_buildings, merge_osm_overture
 from pipeline.stages.process_heights import process_heights
 from pipeline.stages.fetch_roads import fetch_road_network
@@ -87,17 +88,23 @@ def run_pipeline(
     buildings = clean_geometries(buildings)
     roads = clean_geometries(roads)
 
-    # ── Stage 7: Export ──────────────────────────────────
+    # ── Stage 6b: Fetch POIs ─────────────────────────────────────────
+    print("\n[5b/7] Fetching POIs...")
+    pois = fetch_pois(bbox)
+    print(f"  Fetched {len(pois)} POIs")
+
+    # ── Stage 7: Export ──────────────────────────────────────────────
     print("\n[6/7] Exporting GeoJSON files...")
     city_slug = city.lower().replace(" ", "_").replace(",", "")
     city_dir = output_dir / city_slug
 
     export_geojson(buildings, city_dir / "buildings.geojson", "buildings")
     export_geojson(roads, city_dir / "roads.geojson", "roads")
+    export_geojson(pois, city_dir / "pois.geojson", "pois")
 
-    # ── Stage 8: Metadata ────────────────────────────────
+    # ── Stage 8: Metadata ────────────────────────────────────────────
     print("\n[7/7] Generating metadata...")
-    generate_metadata(city, buildings, roads, city_dir / "metadata.json")
+    generate_metadata(city, buildings, roads, city_dir / "metadata.json", pois_gdf=pois)
 
     print(f"\n{'=' * 60}")
     print(f"✅ Pipeline complete! Output: {city_dir}")

--- a/pipeline/stages/export_geojson.py
+++ b/pipeline/stages/export_geojson.py
@@ -41,6 +41,8 @@ def export_geojson(
     elif layer_name == "roads":
         # bridge + layer are used to bake Z elevation; stripped from props after
         keep_cols = ["geometry", "highway", "road_class", "name", "line_width", "bridge", "layer"]
+    elif layer_name == "pois":
+        keep_cols = ["geometry", "name", "category", "amenity_tag"]
     else:
         raise ValueError(f"Unknown layer_name: {layer_name}")
 

--- a/pipeline/stages/fetch_pois.py
+++ b/pipeline/stages/fetch_pois.py
@@ -1,0 +1,192 @@
+"""
+Stage: Fetch OSM Points of Interest (POIs)
+
+Downloads amenity / tourism / shop features from OpenStreetMap via osmnx
+and classifies them into broad display categories.
+
+Categories and their OSM tag sources:
+  food          – amenity: restaurant, cafe, bar, pub, fast_food, ice_cream
+  healthcare    – amenity: hospital, clinic, pharmacy, doctors, dentist
+  education     – amenity: school, university, college, kindergarten, library
+  finance       – amenity: bank, atm, bureau_de_change
+  accommodation – tourism: hotel, hostel, guest_house, motel, apartment
+  culture       – tourism: museum, gallery, theatre, cinema; amenity: theatre, cinema
+  shopping      – shop: supermarket, mall, convenience, bakery, butcher, clothes
+"""
+
+from __future__ import annotations
+
+import osmnx as ox
+import geopandas as gpd
+import pandas as pd
+
+from pipeline.config import OSM_TIMEOUT, OSM_MAX_QUERY_AREA
+
+# ── Category mapping ─────────────────────────────────────────────────────────
+# Each entry: (tag_key, tag_value) → category label
+_AMENITY_TO_CATEGORY: dict[str, str] = {
+    # Food & drink
+    "restaurant":   "food",
+    "cafe":         "food",
+    "bar":          "food",
+    "pub":          "food",
+    "fast_food":    "food",
+    "ice_cream":    "food",
+    "biergarten":   "food",
+    # Healthcare
+    "hospital":     "healthcare",
+    "clinic":       "healthcare",
+    "pharmacy":     "healthcare",
+    "doctors":      "healthcare",
+    "dentist":      "healthcare",
+    # Education
+    "school":       "education",
+    "university":   "education",
+    "college":      "education",
+    "kindergarten": "education",
+    "library":      "education",
+    # Finance
+    "bank":         "finance",
+    "atm":          "finance",
+    "bureau_de_change": "finance",
+}
+
+_TOURISM_TO_CATEGORY: dict[str, str] = {
+    "hotel":       "accommodation",
+    "hostel":      "accommodation",
+    "guest_house": "accommodation",
+    "motel":       "accommodation",
+    "apartment":   "accommodation",
+    "museum":      "culture",
+    "gallery":     "culture",
+    "theatre":     "culture",
+}
+
+_SHOP_CATEGORIES = {
+    "supermarket": "shopping",
+    "mall":        "shopping",
+    "convenience": "shopping",
+    "bakery":      "shopping",
+    "butcher":     "shopping",
+    "clothes":     "shopping",
+    "shoes":       "shopping",
+    "electronics": "shopping",
+    "florist":     "shopping",
+    "hairdresser": "shopping",
+}
+
+
+def _fetch_tag_group(
+    bbox: tuple[float, float, float, float],
+    tag_key: str,
+    tag_values: list[str],
+    category_map: dict[str, str],
+    tag_col: str,
+) -> gpd.GeoDataFrame | None:
+    """Fetch features for one tag key and assign categories."""
+    tags = {tag_key: tag_values}
+    try:
+        gdf = ox.features_from_bbox(bbox=bbox, tags=tags)
+    except Exception:
+        return None
+
+    if gdf.empty:
+        return None
+
+    # Use centroid for polygons so every feature is a Point.
+    # Project to UTM zone 32N (covers northern Italy) for accurate centroids,
+    # then reproject back to WGS84.
+    gdf = gdf.copy()
+    gdf = gdf.to_crs("EPSG:32632")
+    gdf["geometry"] = gdf.geometry.centroid
+    gdf = gdf.to_crs("EPSG:4326")
+
+    # Assign category
+    if tag_col in gdf.columns:
+        gdf["category"] = gdf[tag_col].map(category_map).fillna("other")
+        gdf["amenity_tag"] = gdf[tag_col].astype(str)
+    else:
+        gdf["category"] = "other"
+        gdf["amenity_tag"] = tag_key
+
+    return gdf
+
+
+def fetch_pois(bbox: tuple[float, float, float, float]) -> gpd.GeoDataFrame:
+    """
+    Fetch all POIs in bbox and return a clean GeoDataFrame of Points.
+
+    Args:
+        bbox: (north, south, east, west) in WGS84
+
+    Returns:
+        GeoDataFrame with columns:
+          geometry    – Point (WGS84)
+          name        – string or ""
+          category    – one of: food, healthcare, education, finance,
+                        accommodation, culture, shopping, other
+          amenity_tag – raw OSM tag value (e.g. "restaurant")
+    """
+    ox.settings.timeout = OSM_TIMEOUT
+    ox.settings.max_query_area_size = OSM_MAX_QUERY_AREA
+
+    frames: list[gpd.GeoDataFrame] = []
+
+    # ── Amenity features ────────────────────────────────────────────────
+    amenity_gdf = _fetch_tag_group(
+        bbox,
+        tag_key="amenity",
+        tag_values=list(_AMENITY_TO_CATEGORY.keys()),
+        category_map=_AMENITY_TO_CATEGORY,
+        tag_col="amenity",
+    )
+    if amenity_gdf is not None:
+        frames.append(amenity_gdf)
+
+    # ── Tourism features ────────────────────────────────────────────────
+    tourism_gdf = _fetch_tag_group(
+        bbox,
+        tag_key="tourism",
+        tag_values=list(_TOURISM_TO_CATEGORY.keys()),
+        category_map=_TOURISM_TO_CATEGORY,
+        tag_col="tourism",
+    )
+    if tourism_gdf is not None:
+        frames.append(tourism_gdf)
+
+    # ── Shop features ───────────────────────────────────────────────────
+    shop_gdf = _fetch_tag_group(
+        bbox,
+        tag_key="shop",
+        tag_values=list(_SHOP_CATEGORIES.keys()),
+        category_map=_SHOP_CATEGORIES,
+        tag_col="shop",
+    )
+    if shop_gdf is not None:
+        frames.append(shop_gdf)
+
+    if not frames:
+        # Return empty GeoDataFrame with correct schema
+        return gpd.GeoDataFrame(
+            columns=["geometry", "name", "category", "amenity_tag"],
+            geometry="geometry",
+            crs="EPSG:4326",
+        )
+
+    combined = gpd.GeoDataFrame(pd.concat(frames, ignore_index=True), crs="EPSG:4326")
+
+    # Normalise name column
+    if "name" not in combined.columns:
+        combined["name"] = ""
+    combined["name"] = combined["name"].fillna("").astype(str)
+
+    # Drop duplicates that ended up with identical geometries (osmnx sometimes
+    # returns the same node for multiple tag queries)
+    combined = combined.drop_duplicates(subset=["geometry"]).reset_index(drop=True)
+
+    # Final column selection
+    keep = ["geometry", "name", "category", "amenity_tag"]
+    for col in keep:
+        if col not in combined.columns:
+            combined[col] = ""
+    return combined[keep].copy()

--- a/pipeline/stages/generate_metadata.py
+++ b/pipeline/stages/generate_metadata.py
@@ -16,6 +16,7 @@ def generate_metadata(
     buildings_gdf: gpd.GeoDataFrame,
     roads_gdf: gpd.GeoDataFrame,
     output_path: Path,
+    pois_gdf: gpd.GeoDataFrame | None = None,
 ) -> Path:
     """
     Generate metadata JSON for frontend consumption.
@@ -27,6 +28,7 @@ def generate_metadata(
         buildings_gdf: Processed buildings GeoDataFrame (must have height, height_source)
         roads_gdf: Processed roads GeoDataFrame
         output_path: Destination file path
+        pois_gdf: Optional POI GeoDataFrame
 
     Returns:
         Path to the written file
@@ -52,6 +54,7 @@ def generate_metadata(
         "stats": {
             "buildings_count": len(buildings_gdf),
             "roads_count": len(roads_gdf),
+            "pois_count": len(pois_gdf) if pois_gdf is not None else 0,
             "avg_building_height": round(float(buildings_gdf["height"].mean()), 1),
             "max_building_height": round(float(buildings_gdf["height"].max()), 1),
             "height_sources": source_counts,
@@ -67,6 +70,7 @@ def generate_metadata(
         "files": {
             "buildings": "buildings.geojson",
             "roads": "roads.geojson",
+            "pois": "pois.geojson",
         },
     }
 


### PR DESCRIPTION
## Summary
Closes #22, Closes #23

Adds a full POI (Points of Interest) pipeline stage and renders them as a toggleable ScatterplotLayer on the 3D map.

## Pipeline changes (issue #22)

- **`pipeline/stages/fetch_pois.py`** – new stage: fetches OSM amenity, tourism, and shop features via osmnx for the city bbox. Classifies each into one of 7 categories: `food`, `healthcare`, `education`, `finance`, `accommodation`, `culture`, `shopping`. All polygon/area features are centroid-projected to Points (via UTM 32N for accuracy). Result: **1,045 POIs** for Bolzano.
- **`pipeline/stages/export_geojson.py`** – added `pois` layer type: exports `geometry`, `name`, `category`, `amenity_tag` columns.
- **`pipeline/stages/generate_metadata.py`** – added optional `pois_gdf` parameter; writes `pois_count` to stats and `pois.geojson` to files manifest.
- **`pipeline/run.py`** – wired in `fetch_pois` between road cleaning and export; exports `pois.geojson`; passes `pois_gdf` to metadata.

## Frontend changes (issue #23)

- **`frontend/src/utils/constants.ts`** – `POIS_URL`, `POI_CATEGORY_COLORS` (7 RGBA colours), `POI_CATEGORY_EMOJI` (7 emoji labels).
- **`frontend/src/types/index.ts`** – new `PoiProperties` interface; `MapStoreState` extended with `showPois`, `togglePois`, `selectedPoi`, `setSelectedPoi`.
- **`frontend/src/hooks/useMapData.ts`** – `usePoisData()` hook.
- **`frontend/src/layers/poiLayer.ts`** – `createPoiLayer()`: `ScatterplotLayer` with category colours, `radiusMinPixels: 4`, white stroke, pickable.
- **`frontend/src/store/mapStore.ts`** – `showPois: true`, `togglePois`, `selectedPoi`, `setSelectedPoi`.
- **`frontend/src/components/PoiPanel.tsx`** – new detail panel: appears top-right on POI click, shows category emoji, name, type, coordinates. Dismiss with Close button.
- **`frontend/src/components/Map3D.tsx`** – POI layer added to `layers` memo; click handler distinguishes POI vs building clicks by `info.layer.id`.
- **`frontend/src/components/Controls.tsx`** – POI toggle checkbox; POI count shown in metadata section.
- **`frontend/src/App.tsx`** – renders `<PoiPanel />`.

## Testing
- `npx tsc --noEmit` — zero errors
- Opened at http://localhost:5174 — 1,045 coloured dots render over Bolzano, POI checkbox toggles them, clicking a dot opens the PoiPanel with name/category/coords
